### PR TITLE
Remove Secret Naming Convention

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,12 @@
-image: microsoft/dotnet:2.1-sdk-alpine
+image: mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
 
 stages:
-  - build
-  - test-pack
-  - deploy
+- build
+- test-pack
+- deploy
+
+variables:
+  CONFIGURATION: Release
 
 cache:
   key: "$CI_PIPELINE_ID"
@@ -11,27 +14,27 @@ cache:
 build:
   stage: build
   script:
-    - dotnet build -c Release
+  - dotnet build
   artifacts:
     untracked: true
 
 test:
   stage: test-pack
   script:
-    - dotnet test -c Release ./unit/Test.csproj
+  - dotnet test
 
 pack:
   stage: test-pack
   script:
-    - dotnet pack -c Release -o "$(pwd)/dist/"
+  - dotnet pack --output "$(pwd)/dist/"
   artifacts:
     untracked: false
     paths:
-      - dist/
+    - ./dist/
 
 deploy:
   stage: deploy
   script:
-    - dotnet nuget push ./dist/*.nupkg -k $NUGET_API_KEY
+  - dotnet nuget push --api-key "${NUGET_API_KEY}" ./dist/*.nupkg
   only:
-    - master
+  - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-﻿### What's new in 1.1.0 (Released 2019-04-29)
+﻿### What's new in 2.0.0 (Released 2019-11-05)
+
+* The IDs which the library will check are no longer configured by convention.
+* The configuration now accepts a collection of secret IDs (probably ARNs) from which to read.
+  * It no longer accepts a "base ID".
+
+### What's new in 1.1.0 (Released 2019-04-29)
 
 * The ability to wait for an in-progress secrets refresh to complete before ending execution has been added.
   * This is likely only to be meaningful to a Lambda Function.

--- a/README.md
+++ b/README.md
@@ -34,17 +34,12 @@ There are a few ways to allow an application access to secret configuration valu
 
 In short, setup has two parts. One performed in the application (or, better, in CloudFormation), and one performed in Secrets Manager (which may _also_ be performed in CloudFormation).
 
-In the application, the value for the configuration key `Secrets:BaseId` must be set. This will be the base of the identifiers which the library will look for in Secrets Manager. Two identifiers are queried. One is the plain base ID, and the other is the base ID combined with the running environment. Given the base ID "thing-doer" running in the "Production" environment, the following keys will be queried:
-
-- thing-doer
-- thing-doer/Production
-
-If either is not present, the configuration for that identifier will no-op, having no effect on configuration.
+In the application, the index values for the configuration key `Secrets:Ids` must be set. (That is, `Secrets:Ids:0`, `Secrets:Ids:1`, &c.) These are the identifiers which the library will look for in Secrets Manager. If a specified identifier is not present, the configuration will fail.
 
 Add the Secrets Manager configuration to the application configuration with the extension method for `IConfiguration`, similar to any other configuration source. For example:
 
 ```csharp
-config.AddAWSSecretsManager(hostingContext.HostingEnvironment.EnvironmentName);
+config.AddAWSSecretsManager();
 ```
 
 This can be added to a reuable host, one like `WebHost.CreateDefaultBuilder<TStartup>()` from ASP.NET Core. Or see if [your favorite hosting library][] already has one configured.

--- a/src/Tiger.Secrets/ConfigurationExtensions.cs
+++ b/src/Tiger.Secrets/ConfigurationExtensions.cs
@@ -26,7 +26,7 @@ namespace Tiger.Secrets.Lambda
     public static class ConfigurationExtensions
     {
         /// <summary>
-        /// Blocks execution of a Lambda Function until any instances of <see cref="AWSSecretsManagerConfigurationProvider"/>
+        /// Blocks execution of a Lambda Function until any instances of <see cref="SecretsManagerConfigurationProvider"/>
         /// added to the configuration have completed a reload of configuration from Secrets Manager if such a reload
         /// is in progress when this method is invoked.
         /// </summary>
@@ -39,7 +39,7 @@ namespace Tiger.Secrets.Lambda
 
             if (!(configuration is IConfigurationRoot configurationRoot)) { return; }
 
-            foreach (var provider in configurationRoot.Providers.OfType<AWSSecretsManagerConfigurationProvider>())
+            foreach (var provider in configurationRoot.Providers.OfType<SecretsManagerConfigurationProvider>())
             {
                 provider.WaitForReloadToComplete(timeout);
             }

--- a/src/Tiger.Secrets/Properties/Resources.Designer.cs
+++ b/src/Tiger.Secrets/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Tiger.Secrets.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/Tiger.Secrets/SecretsManagerConfigurationSource.cs
+++ b/src/Tiger.Secrets/SecretsManagerConfigurationSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AWSSecretsManagerConfigurationSource.cs" company="Cimpress, Inc.">
+﻿// <copyright file="SecretsManagerConfigurationSource.cs" company="Cimpress, Inc.">
 //   Copyright 2018 Cimpress, Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,17 +23,16 @@ using static Tiger.Secrets.Properties.Resources;
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>A source of AWS Secrets Manager configuration key/values for an application.</summary>
-    public sealed class AWSSecretsManagerConfigurationSource
+    public sealed class SecretsManagerConfigurationSource
         : IConfigurationSource
     {
-        /// <summary>Initializes a new instance of the <see cref="AWSSecretsManagerConfigurationSource"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="SecretsManagerConfigurationSource"/> class.</summary>
         /// <param name="secretsManagerClient">The client to use to retrieve secret values.</param>
-        /// <param name="secretId">The unique identifer of the secret to use for configuration.</param>
+        /// <param name="secretId">The unique identifier of the secret to use for configuration.</param>
         /// <param name="expiration">The amount of time after which configuration will be reloaded.</param>
         /// <exception cref="ArgumentNullException"><paramref name="secretsManagerClient"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="secretId"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="expiration"/> is negative.</exception>
-        public AWSSecretsManagerConfigurationSource(
+        public SecretsManagerConfigurationSource(
             [NotNull] IAmazonSecretsManager secretsManagerClient,
             [NotNull] string secretId,
             [NotNull] TimeSpan expiration)
@@ -48,7 +47,7 @@ namespace Microsoft.Extensions.Configuration
         /// <summary>Gets the client to use to retrieve secret values.</summary>
         public IAmazonSecretsManager SecretsManagerClient { get; }
 
-        /// <summary>Gets the unique identifer of the secret to use for configuration.</summary>
+        /// <summary>Gets the unique identifier of the secret to use for configuration.</summary>
         public string SecretId { get; }
 
         /// <summary>Gets the amount of time after which configuration will be reloaded.</summary>
@@ -56,6 +55,6 @@ namespace Microsoft.Extensions.Configuration
 
         /// <inheritdoc/>
         IConfigurationProvider IConfigurationSource.Build(IConfigurationBuilder builder) =>
-            new AWSSecretsManagerConfigurationProvider(this);
+            new SecretsManagerConfigurationProvider(this);
     }
 }

--- a/src/Tiger.Secrets/SecretsOptions.cs
+++ b/src/Tiger.Secrets/SecretsOptions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Microsoft.Extensions.Configuration
@@ -24,15 +25,8 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public sealed class SecretsOptions
     {
-        /// <summary>Gets or sets the base of the unique identifier of secrets.</summary>
-        /// <remarks><para>
-        /// This will be used as-is to retrieve secrets applicable
-        /// to this application in all environments, and combined
-        /// with the name of the current environment to retrieve
-        /// secrets applicable to this application in the current
-        /// environment.
-        /// </para></remarks>
-        public string BaseId { get; set; }
+        /// <summary>Gets the collection of unique identifiers of the secrets to retrieve.</summary>
+        public List<string> Ids { get; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the amount of time after which configuration will be reloaded.

--- a/src/Tiger.Secrets/Tiger.Secrets.csproj
+++ b/src/Tiger.Secrets/Tiger.Secrets.csproj
@@ -4,73 +4,56 @@
     <Description>Integrates AWS Secrets Manager into the Microsoft.Extensions.Configuration ecosystem.</Description>
     <Copyright>©Cimpress 2019</Copyright>
     <AssemblyTitle>Tiger Secrets</AssemblyTitle>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>cosborn@cimpress.com</Authors>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <CodeAnalysisRuleSet>../../Tiger.ruleset</CodeAnalysisRuleSet>
     <AssemblyName>Tiger.Secrets</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Tiger.Secrets</PackageId>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageTags>secrets;secrets manager;configuration</PackageTags>
-    <PackageReleaseNotes><![CDATA[➟ Release 1.1.0
-⁃ The ability to wait for an in-progress secrets refresh to complete before ending execution has been added.
-  ⁃ This is likely only to be meaningful to a Lambda Function.
-
-➟ Release 1.0.0
-⁃ Everything is new!
+    <PackageReleaseNotes><![CDATA[➟ Release 2.0.0
+⁃ The secret IDs which the library will check are no longer configured by convention.
+⁃ The configuration now accepts a collection of secret IDs (probably ARNs) from which to read.
+  ⁃ It no longer accepts a "base ID".
 ]]></PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Cimpress-MCP/Tiger-Secrets</PackageProjectUrl>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/Cimpress-MCP/Tiger-Secrets/master/tiger_logo.png</PackageIconUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageIcon>tiger_logo.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Cimpress-MCP/Tiger-Secrets.git</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Features>IOperation</Features>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="../../stylecop.json" />
+    <None Include="../../tiger_logo.png" Pack="True" PackagePath="/" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
   </ItemGroup>
-
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.101.71" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.101" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
-
-
-  <ItemGroup>
-    <Compile Update="Properties\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/unit/Generators.cs
+++ b/unit/Generators.cs
@@ -2,7 +2,7 @@
 using JetBrains.Annotations;
 using static System.StringComparison;
 using static Microsoft.Extensions.Configuration.ConfigurationPath;
-using static Microsoft.Extensions.Configuration.AWSSecretsManagerConfigurationProvider;
+using static Microsoft.Extensions.Configuration.SecretsManagerConfigurationProvider;
 
 namespace Test
 {

--- a/unit/NormalizationTests.cs
+++ b/unit/NormalizationTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Configuration.Test;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using static Microsoft.Extensions.Configuration.AWSSecretsManagerConfigurationProvider;
+using static Microsoft.Extensions.Configuration.SecretsManagerConfigurationProvider;
 using static Microsoft.Extensions.Configuration.ConfigurationPath;
 
 namespace Test
@@ -35,8 +35,8 @@ namespace Test
             var client = new Mock<IAmazonSecretsManager>();
             client.Setup(m => m.GetSecretValueAsync(It.IsNotNull<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
 
-            var configurationSource = new AWSSecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
-            var sut = new AWSSecretsManagerConfigurationProvider(configurationSource);
+            var configurationSource = new SecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
+            var sut = new SecretsManagerConfigurationProvider(configurationSource);
             sut.Load();
 
             client.Verify(m => m.GetSecretValueAsync(It.Is<GetSecretValueRequest>(r => r.SecretId == secretId.Get), It.IsAny<CancellationToken>()), Times.Once);
@@ -58,8 +58,8 @@ namespace Test
             var client = new Mock<IAmazonSecretsManager>();
             client.Setup(m => m.GetSecretValueAsync(It.IsNotNull<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
 
-            var configurationSource = new AWSSecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
-            var sut = new AWSSecretsManagerConfigurationProvider(configurationSource);
+            var configurationSource = new SecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
+            var sut = new SecretsManagerConfigurationProvider(configurationSource);
             sut.Load();
 
             client.Verify(m => m.GetSecretValueAsync(It.Is<GetSecretValueRequest>(r => r.SecretId == secretId.Get), It.IsAny<CancellationToken>()), Times.Once);
@@ -81,8 +81,8 @@ namespace Test
             var client = new Mock<IAmazonSecretsManager>();
             client.Setup(m => m.GetSecretValueAsync(It.IsNotNull<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
 
-            var configurationSource = new AWSSecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
-            var sut = new AWSSecretsManagerConfigurationProvider(configurationSource);
+            var configurationSource = new SecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
+            var sut = new SecretsManagerConfigurationProvider(configurationSource);
             sut.Load();
 
             var compoundKey = Combine(key.Select(k => k.Get));
@@ -101,15 +101,15 @@ namespace Test
             var client = new Mock<IAmazonSecretsManager>();
             client.Setup(m => m.GetSecretValueAsync(It.IsNotNull<GetSecretValueRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
 
-            var configurationSource = new AWSSecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
-            var sut = new AWSSecretsManagerConfigurationProvider(configurationSource);
+            var configurationSource = new SecretsManagerConfigurationSource(client.Object, secretId.Get, Timeout.InfiniteTimeSpan);
+            var sut = new SecretsManagerConfigurationProvider(configurationSource);
             sut.Load();
 
             var compoundKey = Combine(key.Get.Select(k => k.Get));
             client.Verify(m => m.GetSecretValueAsync(It.Is<GetSecretValueRequest>(r => r.SecretId == secretId.Get), It.IsAny<CancellationToken>()), Times.Once);
             Assert.Equal(value.Get, sut.Get(compoundKey));
 
-            ImmutableDictionary<string, object> GenerateDatum(in ReadOnlySpan<ConfigurationKey> k, string v)
+            static ImmutableDictionary<string, object> GenerateDatum(in ReadOnlySpan<ConfigurationKey> k, string v)
             {
                 var (head, tail) = k;
 

--- a/unit/ReloadTests.cs
+++ b/unit/ReloadTests.cs
@@ -16,8 +16,8 @@ namespace Test
         {
             var client = Mock.Of<IAmazonSecretsManager>();
 
-            var configurationSource = new AWSSecretsManagerConfigurationSource(client, secretId.Get, Timeout.InfiniteTimeSpan);
-            var sut = new AWSSecretsManagerConfigurationProvider(configurationSource);
+            var configurationSource = new SecretsManagerConfigurationSource(client, secretId.Get, Timeout.InfiniteTimeSpan);
+            var sut = new SecretsManagerConfigurationProvider(configurationSource);
 
             // note(cosborn) Assertion controlled by the "longRunningTestSeconds" parameter in `xunit.runner.json`.
             sut.WaitForReloadToComplete(Timeout.InfiniteTimeSpan);

--- a/unit/Test.csproj
+++ b/unit/Test.csproj
@@ -1,30 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../Test.ruleset</CodeAnalysisRuleSet>
-    <AssemblyName>Tiger.Secrets.UnitTest</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Features>IOperation</Features>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="3.0.0-alpha4" />
-    <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Now secrets' IDs can be arbitrary, as configured by the user.