### PR TITLE
Handle Misconfigured Options More Gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿### What's new in 2.0.0 (Released 2019-11-05)
+﻿### What's new in 2.0.1 (Released 2020-01-13)
+
+* Misconfigured options are now handled by bailing out gracefully.
+
+### What's new in 2.0.0 (Released 2019-11-05)
 
 * The IDs which the library will check are no longer configured by convention.
 * The configuration now accepts a collection of secret IDs (probably ARNs) from which to read.

--- a/src/Tiger.Secrets/SecretsManagerConfigurationBuilderExtensions.cs
+++ b/src/Tiger.Secrets/SecretsManagerConfigurationBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Configuration
             var configuration = builder.AddEnvironmentVariables().Build();
             var secretsOpts = configuration.GetSection(sectionName).Get<SecretsOptions>();
 
-            if (secretsOpts.Ids.Count == 0)
+            if (secretsOpts is null || secretsOpts.Ids.Count == 0)
             {
                 // note(cosborn) Don't pay the cost of creating a service client if we can avoid it.
                 return builder;

--- a/src/Tiger.Secrets/Tiger.Secrets.csproj
+++ b/src/Tiger.Secrets/Tiger.Secrets.csproj
@@ -4,7 +4,7 @@
     <Description>Integrates AWS Secrets Manager into the Microsoft.Extensions.Configuration ecosystem.</Description>
     <Copyright>©Cimpress 2019</Copyright>
     <AssemblyTitle>Tiger Secrets</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <Authors>cosborn@cimpress.com</Authors>
     <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <CodeAnalysisRuleSet>../../Tiger.ruleset</CodeAnalysisRuleSet>
@@ -14,7 +14,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageTags>secrets;secrets manager;configuration</PackageTags>
-    <PackageReleaseNotes><![CDATA[➟ Release 2.0.0
+    <PackageReleaseNotes><![CDATA[➟ Release 2.0.1
+⁃ Misconfigured options are now handled by bailing out gracefully.
+
+➟ Release 2.0.0
 ⁃ The secret IDs which the library will check are no longer configured by convention.
 ⁃ The configuration now accepts a collection of secret IDs (probably ARNs) from which to read.
   ⁃ It no longer accepts a "base ID".


### PR DESCRIPTION
Calling `Get` on a Configuration Section doesn't operate in the same
way as using an `IOptions<TOptions>`, so we have to protect against
`null`.